### PR TITLE
Consistent spelling of encryption

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Features
 Terrascan will perform tests on your terraform templates to ensure:
 
 - **Encryption**
-    - Server Side Encription (SSE) enabled
+    - Server Side Encryption (SSE) enabled
     - Use of AWS Key Management Service (KMS) with Customer Managed Keys (CMK)
     - Use of SSL/TLS and proper configuration
 - **Security Groups**

--- a/terrascan/terrascan.py
+++ b/terrascan/terrascan.py
@@ -69,7 +69,7 @@ def create_parser():
         '-t',
         '--tests',
         help='''Comma separated list of test to run or "all" for all tests
-(e.g. encryption,security_group) Valid values include:encription,
+(e.g. encryption,security_group) Valid values include:encryption,
 logging_and_monitoring, public_exposure, security_group''',
         nargs=1,
         default=['all']


### PR DESCRIPTION
Prevents using -t encription from the usage output.