### PR TITLE
Added GCP tests

### DIFF
--- a/terrascan/checks/encryption.py
+++ b/terrascan/checks/encryption.py
@@ -25,7 +25,22 @@ class TestEncryption(unittest.TestCase):
         self.v.error_if_property_missing()
         self.v.enable_variable_expansion()
         self.v.resources(
-            'aws_alb_listener').property('port').should_equal('443')
+                         'aws_alb_listener',
+                        ).property('port').should_equal('443')
+
+    def test_gcp_ssl_policy(self):
+        self.v.error_if_property_missing()
+        self.v.enable_variable_expansion()
+        self.v.resources(
+                        'google_compute_ssl_policy',
+                       ).property('min_tls_version').should_equal('1.2')
+
+    def test_gcp_disk_encryption(self):
+        self.v.error_if_property_missing()
+        self.v.enable_variable_expansion()
+        self.v.resources(
+                         'google_compute_disk',
+                        ).should_have_properties(['disk_encryption_key'])
 
     def test_aws_alb_listener_protocol(self):
         # Assert that protocol is not http
@@ -362,7 +377,7 @@ class TestEncryption(unittest.TestCase):
             'aws_ssm_parameter').property(
             'type').should_equal('SecureString')
 
-    def test_aws_instance(self):
+    def test_zach_instance(self):
         self.v.error_if_property_missing()
         self.v.enable_variable_expansion()
         self.v.resources('aws_instance').resource_list
@@ -374,3 +389,6 @@ class TestEncryption(unittest.TestCase):
         self.v.resources(
             'aws_ssm_parameter').should_have_properties(
             ['key_id'])
+        return dir(self.v.resources(
+            'aws_ssm_parameter').should_have_properties(
+            ['key_id']))

--- a/terrascan/checks/encryption.py
+++ b/terrascan/checks/encryption.py
@@ -377,11 +377,6 @@ class TestEncryption(unittest.TestCase):
             'aws_ssm_parameter').property(
             'type').should_equal('SecureString')
 
-    def test_zach_instance(self):
-        self.v.error_if_property_missing()
-        self.v.enable_variable_expansion()
-        self.v.resources('aws_instance').resource_list
-
     def test_aws_ssm_parameter_kms(self):
         # Assert resource has a KMS with CMK
         self.v.error_if_property_missing()

--- a/terrascan/checks/encryption.py
+++ b/terrascan/checks/encryption.py
@@ -359,7 +359,12 @@ class TestEncryption(unittest.TestCase):
         self.v.enable_variable_expansion()
         self.v.resources(
             'aws_ssm_parameter').property(
-            'type').should_equal("SecureString")
+            'type').should_equal('SecureString')
+
+    def test_aws_instance(self):
+        self.v.error_if_property_missing()
+        self.v.enable_variable_expansion()
+        self.v.resources('aws_instance').resource_list
 
     def test_aws_ssm_parameter_kms(self):
         # Assert resource has a KMS with CMK

--- a/terrascan/checks/public_exposure.py
+++ b/terrascan/checks/public_exposure.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
 """Tests for public exposure configuration in terraform templates"""
-
-import unittest
 import os
+import unittest
+
 import terraform_validate
 
 

--- a/terrascan/checks/security_group.py
+++ b/terrascan/checks/security_group.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
 """Tests for security group configuration in terraform templates"""
-
-import unittest
 import os
+import unittest
+
 import terraform_validate
 
 
@@ -19,6 +19,15 @@ class TestSecurityGroups(unittest.TestCase):
                 # os.path.realpath(__file__)), settings.TERRAFORM_LOCATION)
                 os.path.realpath(__file__)), self.TERRAFORM_LOCATION)
         self.v = terraform_validate.Validator(self.path)
+
+    def test_gcp_firewall_rules(self):
+        self.v.enable_variable_expansion()
+        self.v.error_if_property_missing()
+        self.v.resources(
+                         'google_compute_firewall',
+                        ).property(
+                                   'destination_ranges',
+                                  ).list_should_not_contain('0.0.0.0/0')
 
     def test_aws_db_security_group_used(self):
         # This SG type exists outside of VPC (e.g. ec2 classic)

--- a/tests/infrastructure/fail/gcp_main.tf
+++ b/tests/infrastructure/fail/gcp_main.tf
@@ -5,3 +5,7 @@ resource "google_compute_ssl_policy" "default-ssl" {
   name = "test-ssl-policy"
   min_tls_version = "1.1"
 }
+resource "google_compute_firewall" "default_firewall" {
+  name = "test-firewall"
+  destination_ranges = ["0.0.0.0/0"]
+}

--- a/tests/infrastructure/fail/gcp_main.tf
+++ b/tests/infrastructure/fail/gcp_main.tf
@@ -1,0 +1,7 @@
+resource "google_compute_disk" "default" {
+  name = "test-disk"
+}
+resource "google_compute_ssl_policy" "default-ssl" {
+  name = "test-ssl-policy"
+  min_tls_version = "1.1"
+}


### PR DESCRIPTION
1.  Added test to check for encrypted volumes on GCE
2. Added test to check if TLS v. is 1.2 (Would prefer if there was a way to evaluate less than X version)
3. Added test to check for GCE firewall rules not allowing `0.0.0.0/0` to `destination_ranges`